### PR TITLE
Update apprunner_hosting_stack.py: AppRunner Export name modified

### DIFF
--- a/search_tutorials/apprunner_hosting_stack.py
+++ b/search_tutorials/apprunner_hosting_stack.py
@@ -90,7 +90,7 @@ class AppRunnerHostingStack(Stack):
             self,
             f"apprunner-url-{env_name}",
             value=app_runner_ui.attr_service_url,
-            export_name="ServiceUrl",
+            export_name=f"ServiceUrl-{env_name}",
         )
 
     def suppressor(self, constructs, id, reason):


### PR DESCRIPTION
*Issue #, if available:* Deploying multiple stacks in the same account could cause the AppRunner stack to fail

*Description of changes:* fixed by modifying the CfnOutput


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
